### PR TITLE
chore: standardize dependency and intake policy

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: false
 contact_links:
+  - name: Questions and discussions
+    url: https://github.com/authenticiq/agent-receipts/discussions
+    about: Use Discussions for usage questions, design discussion, and support requests.
   - name: Security policy
     url: https://github.com/authenticiq/agent-receipts/security/policy
     about: Do not file vulnerabilities publicly. Follow SECURITY.md and email hello@authenticiq.ai.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "08:00"
+      timezone: UTC
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+    commit-message:
+      prefix: "chore(deps)"
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "08:30"
+      timezone: UTC
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+    commit-message:
+      prefix: "chore(ci)"

--- a/docs/MAINTENANCE_POLICY.md
+++ b/docs/MAINTENANCE_POLICY.md
@@ -1,0 +1,48 @@
+# Maintenance Policy
+
+This document defines how dependency updates, issue intake, and maintainer triage should work in this repo.
+
+## Dependency And Security Updates
+
+- Dependabot configuration lives in `.github/dependabot.yml`.
+- Dependabot should open small, reviewable PRs on a weekly cadence.
+- Dependency PRs only merge with green CI.
+- Security alerts and automated security fixes should stay enabled on GitHub.
+- Any update that touches verification, signing, canonicalization, or fixture integrity gets manual review even if it looks routine.
+
+## Issues Vs Discussions
+
+Use Issues for:
+- bugs and regressions
+- feature requests
+- spec or contract changes
+- release-blocking work
+
+Use Discussions for:
+- usage questions
+- design discussion
+- integration help
+- examples, showcases, and implementation notes
+
+Do not use Issues or Discussions for suspected vulnerabilities. Follow `SECURITY.md`.
+
+## Triage Rules
+
+- New issues and discussions should be labeled or redirected within 7 days.
+- Anything that looks release-blocking should be triaged the same day when practical.
+- Security-sensitive public reports should be redirected to private reporting immediately.
+- If a question is filed as an issue, redirect it to Discussions and close the issue once the handoff is clear.
+
+## Standard Labels
+
+- `bug`: confirmed defect or regression
+- `docs`: documentation work
+- `enhancement`: feature or improvement request
+- `question`: issue needs clarification or should move to Discussions
+- `spec`: contract, schema, or design-surface change
+- `security`: security-sensitive work that is safe to track publicly
+- `release-blocker`: must be resolved before the next release
+- `breaking-change`: intentionally incompatible public change
+- `dependencies`: dependency or automation update work
+- `good first issue`: suitable for a new contributor
+- `help wanted`: maintainer welcomes outside help


### PR DESCRIPTION
## Summary
- add Dependabot configuration for cargo and GitHub Actions
- add a maintainer policy covering dependency updates, discussions routing, and triage rules
- route questions to Discussions from the issue form config

## Validation
- cargo fmt --all --check
- cargo run --bin generate-fixtures
- git diff --exit-code -- testvectors
- cargo test
- ../.tools/gitleaks dir . --config gitleaks.toml
