### PR TITLE
Add weekly triage maintainer intake

### DIFF
--- a/.github/ISSUE_TEMPLATE/weekly_triage.yml
+++ b/.github/ISSUE_TEMPLATE/weekly_triage.yml
@@ -1,0 +1,32 @@
+name: Weekly triage
+description: Maintainer checklist for the weekly repo review
+title: "[weekly-triage]: "
+labels: ["maintenance"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this issue to capture the weekly maintenance pass for this repo.
+  - type: textarea
+    id: ci
+    attributes:
+      label: CI and automation review
+      description: Note any failing runs, flaky behavior, or workflow drift.
+      placeholder: Review CI health, failed jobs, and Dependabot PRs.
+    validations:
+      required: true
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Weekly checklist
+      options:
+        - label: Reviewed open issues and redirected questions to Discussions where appropriate
+        - label: Reviewed open pull requests and release-blocking work
+        - label: Reviewed security alerts and dependency update PRs
+        - label: Checked docs, examples, and quickstarts for drift
+        - label: Identified anything that should block the next release
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes and follow-up
+      description: Capture decisions, links, and any follow-up work.

--- a/docs/MAINTENANCE_POLICY.md
+++ b/docs/MAINTENANCE_POLICY.md
@@ -32,6 +32,7 @@ Do not use Issues or Discussions for suspected vulnerabilities. Follow `SECURITY
 - Anything that looks release-blocking should be triaged the same day when practical.
 - Security-sensitive public reports should be redirected to private reporting immediately.
 - If a question is filed as an issue, redirect it to Discussions and close the issue once the handoff is clear.
+- Use the weekly triage issue template to capture the recurring maintainer review when helpful.
 
 ## Standard Labels
 
@@ -41,6 +42,7 @@ Do not use Issues or Discussions for suspected vulnerabilities. Follow `SECURITY
 - `question`: issue needs clarification or should move to Discussions
 - `spec`: contract, schema, or design-surface change
 - `security`: security-sensitive work that is safe to track publicly
+- `maintenance`: recurring maintainer operations, triage, and repo hygiene work
 - `release-blocker`: must be resolved before the next release
 - `breaking-change`: intentionally incompatible public change
 - `dependencies`: dependency or automation update work


### PR DESCRIPTION
## Summary
- add a weekly triage issue template for recurring maintainer review
- document the weekly triage loop in the maintenance policy

## Validation
- cargo fmt --all --check
- cargo run --bin generate-fixtures
- git diff --exit-code -- testvectors
- cargo test
- ../.tools/gitleaks dir . --config gitleaks.toml