### PR TITLE
Automate weekly triage intake

### DIFF
--- a/.github/workflows/weekly-triage.yml
+++ b/.github/workflows/weekly-triage.yml
@@ -1,0 +1,105 @@
+name: weekly-triage
+
+on:
+  schedule:
+    - cron: "15 10 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: weekly-triage-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  open-weekly-triage-issue:
+    name: open-weekly-triage-issue
+    runs-on: ubuntu-latest
+    steps:
+      - name: Open weekly triage issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            function getIsoWeekKey(date) {
+              const workingDate = new Date(Date.UTC(
+                date.getUTCFullYear(),
+                date.getUTCMonth(),
+                date.getUTCDate()
+              ));
+              const day = workingDate.getUTCDay() || 7;
+              workingDate.setUTCDate(workingDate.getUTCDate() + 4 - day);
+
+              const yearStart = new Date(Date.UTC(workingDate.getUTCFullYear(), 0, 1));
+              const week = Math.ceil((((workingDate - yearStart) / 86400000) + 1) / 7);
+
+              return `${workingDate.getUTCFullYear()}-W${String(week).padStart(2, "0")}`;
+            }
+
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const weekKey = getIsoWeekKey(new Date());
+            const title = `[weekly-triage]: ${weekKey}`;
+
+            const openIssues = await github.paginate(github.rest.issues.listForRepo, {
+              owner,
+              repo,
+              state: "open",
+              per_page: 100,
+            });
+
+            const existing = openIssues.find(
+              (issue) => !issue.pull_request && issue.title === title
+            );
+
+            if (existing) {
+              core.info(`Weekly triage issue already exists: #${existing.number}`);
+              return;
+            }
+
+            const labels = await github.paginate(github.rest.issues.listLabelsForRepo, {
+              owner,
+              repo,
+              per_page: 100,
+            });
+            const hasMaintenanceLabel = labels.some(
+              (label) => label.name === "maintenance"
+            );
+
+            if (!hasMaintenanceLabel) {
+              core.warning("Maintenance label does not exist yet; creating issue without it.");
+            }
+
+            const issueBody = [
+              "Automated weekly maintainer review created by `.github/workflows/weekly-triage.yml`.",
+              "",
+              "## CI and automation review",
+              "- Review failing or flaky Actions runs.",
+              "- Review Dependabot PRs and security alerts.",
+              "",
+              "## Weekly checklist",
+              "- [ ] Reviewed open issues and redirected questions to Discussions where appropriate",
+              "- [ ] Reviewed open pull requests and release-blocking work",
+              "- [ ] Reviewed security alerts and dependency update PRs",
+              "- [ ] Checked docs, examples, and quickstarts for drift",
+              "- [ ] Identified anything that should block the next release",
+              "",
+              "## Links",
+              `- Actions: ${context.serverUrl}/${owner}/${repo}/actions`,
+              `- Issues: ${context.serverUrl}/${owner}/${repo}/issues`,
+              `- Pull requests: ${context.serverUrl}/${owner}/${repo}/pulls`,
+              "",
+              "## Notes and follow-up",
+              "- Add links, decisions, and follow-up items here.",
+            ].join("\n");
+
+            const issue = await github.rest.issues.create({
+              owner,
+              repo,
+              title,
+              body: issueBody,
+              ...(hasMaintenanceLabel ? { labels: ["maintenance"] } : {}),
+            });
+
+            core.notice(`Created weekly triage issue #${issue.data.number}`);

--- a/docs/MAINTENANCE_POLICY.md
+++ b/docs/MAINTENANCE_POLICY.md
@@ -5,7 +5,7 @@ This document defines how dependency updates, issue intake, and maintainer triag
 ## Dependency And Security Updates
 
 - Dependabot configuration lives in `.github/dependabot.yml`.
-- Dependabot should open small, reviewable PRs on a weekly cadence.
+- Dependabot tracks Cargo and GitHub Actions on a weekly cadence.
 - Dependency PRs only merge with green CI.
 - Security alerts and automated security fixes should stay enabled on GitHub.
 - Any update that touches verification, signing, canonicalization, or fixture integrity gets manual review even if it looks routine.
@@ -32,7 +32,7 @@ Do not use Issues or Discussions for suspected vulnerabilities. Follow `SECURITY
 - Anything that looks release-blocking should be triaged the same day when practical.
 - Security-sensitive public reports should be redirected to private reporting immediately.
 - If a question is filed as an issue, redirect it to Discussions and close the issue once the handoff is clear.
-- Use the weekly triage issue template to capture the recurring maintainer review when helpful.
+- The scheduled weekly triage workflow should open the default review issue each Monday. Use the weekly triage issue template for extra passes or backfills.
 
 ## Standard Labels
 


### PR DESCRIPTION
## Summary
- add a scheduled weekly triage workflow that opens the recurring maintainer review issue automatically
- update the maintenance policy to describe the automated weekly review cadence
- make the existing Dependabot coverage explicit for Cargo and GitHub Actions in this repo

## Validation
- cargo fmt --all --check
- cargo run --bin generate-fixtures
- git diff --exit-code -- testvectors
- cargo test
- ../.tools/gitleaks dir . --config gitleaks.toml