### PR TITLE
Refresh Week 1 documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,88 @@
 
 Post-quantum receipt schema and verifier for AI agent actions.
 
-## Status
+`agent-receipts` defines a neutral JSON contract for signed action receipts and Merkle inclusion batches, plus a Rust verifier CLI and library that validate them offline. It is maintained by AuthenticIQ. StrataCodes is a downstream commercial implementation, not the parent brand of the OSS and not a required service dependency.
 
-This repository is in Week 1 specification draft status.
+Current surface area:
+- `receipt-v1` and `batch-v1` schemas
+- Rust verifier CLI and library
+- conformance fixtures in `testvectors/`
+- ML-DSA-87 as the preferred algorithm, with Ed25519 kept as transitional compatibility
+- no packaged release binaries or TS/Python bindings yet
 
-Current draft artifacts:
-- `spec/receipt-v1.schema.json`
-- `spec/batch-v1.schema.json`
-- `spec/RATIONALE.md`
-- `spec/THREAT_MODEL.md`
-- `testvectors/MATRIX.md`
+## Why you'd use it
 
-This project is intended to be usable independently of StrataCodes.
+- Agent platforms and MCP server authors: emit portable, signed receipts for tool calls without depending on a hosted control plane.
+- Compliance and audit teams: verify a claim offline from a receipt file, a batch file, and a trusted public key directory.
+- Researchers and journalists: preserve tamper-evident evidence that an agent action was asserted by a specific signer.
 
-Maintained by AuthenticIQ. StrataCodes may later use this project in production as a downstream commercial implementation.
+## Install
+
+The fastest path today is from a local clone. That keeps the demo fixtures and public keys in place and makes the first verification run copy-pasteable.
+
+```bash
+git clone https://github.com/authenticiq/agent-receipts.git
+cd agent-receipts
+cargo run --bin receipts -- --help
+```
+
+If you want the CLI on your local `PATH`, install it from the checked-out repo:
+
+```bash
+cargo install --locked --path .
+receipts --help
+```
+
+The built-in demo path assumes a checked-out repo because the default key directory points at `testvectors/keys`. If you verify your own receipts or run the binary outside this checkout, pass `--keys-dir` explicitly.
+
+## Verify your first receipt
+
+From the repo root:
+
+```bash
+cargo run --bin receipts -- schema-check testvectors/valid/minimal-single-ml-dsa-87.json
+cargo run --bin receipts -- verify testvectors/valid/minimal-single-ml-dsa-87.json
+cargo run --bin receipts -- inspect testvectors/valid/minimal-single-ml-dsa-87.json
+```
+
+You should see:
+
+```text
+schema-check ok: agent-receipts/v1
+verify ok: 01JABCD0000000000000000000
+```
+
+For the next two verifier surfaces:
+
+```bash
+cargo run --bin receipts -- verify-batch testvectors/batches/two-receipts-valid-batch.json
+cargo run --bin receipts -- verify-chain testvectors/chains/three-step-lineage.json
+```
+
+See [docs/QUICKSTART.md](docs/QUICKSTART.md) for the 10-minute path, expected outputs, and a failure demo.
+
+## How it relates to adjacent tools
+
+| System | Primary object | What it is good at | Relationship to `agent-receipts` |
+| --- | --- | --- | --- |
+| `agent-receipts` | Runtime agent actions | Signed action receipts and offline verification | This repo is the contract and reference verifier |
+| Sigstore | Build and release artifacts | Artifact signing, identity, and release provenance | Complementary; not a runtime action format |
+| in-toto | Supply-chain steps and attestations | Build pipeline claims and policy evaluation | Complementary; broader supply-chain focus |
+| C2PA | Media assets | Content credentials and media provenance | Complementary; not aimed at tool-call receipts |
+| OpenTelemetry | Traces, logs, and metrics | Operational observability | Complementary; not tamper-evident by itself |
+
+## Spec and conformance
+
+- Receipt schema: [spec/receipt-v1.schema.json](spec/receipt-v1.schema.json)
+- Batch schema: [spec/batch-v1.schema.json](spec/batch-v1.schema.json)
+- Design rationale: [spec/RATIONALE.md](spec/RATIONALE.md)
+- Threat model: [spec/THREAT_MODEL.md](spec/THREAT_MODEL.md)
+- Conformance matrix: [testvectors/MATRIX.md](testvectors/MATRIX.md)
+- Quickstart: [docs/QUICKSTART.md](docs/QUICKSTART.md)
+- Integration guide: [docs/INTEGRATION.md](docs/INTEGRATION.md)
+
+## Contributing and security
+
+This project uses DCO sign-off rather than a CLA. See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution rules and review expectations.
+
+Do not open public issues for vulnerabilities. Report security issues privately to `hello@authenticiq.ai` as described in [SECURITY.md](SECURITY.md).

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -1,0 +1,124 @@
+# Integration Guide
+
+This guide is for teams that want to emit `agent-receipts` from their own agent runtime, tool server, or audit pipeline.
+
+## Current integration surface
+
+- The shipped integration surface today is the JSON schema contract plus the Rust verifier CLI and library.
+- TypeScript and Python bindings are planned, but they are not published yet.
+- If you are not integrating from Rust yet, the easiest path is to emit schema-conformant JSON and verify it with the Rust CLI in CI or in your ingest pipeline.
+
+## What an emitter must produce
+
+A valid receipt needs:
+
+- `schema_version`: `agent-receipts/v1`
+- `receipt_id`: ULID
+- `issued_at`: RFC 3339 timestamp
+- `payload.event_type`: open vocabulary such as `tool_call`
+- `payload.actor`: who acted
+- `payload.tool`: what execution surface handled the action
+- `payload.inputs_hash` and `payload.outputs_hash`: content digests, not raw payload bodies
+- `signature`: detached signature metadata including algorithm, key identifier, encoding, and value
+
+Merkle inclusion data does not belong inside the signed receipt. If you batch receipts, emit a separate `batch-v1` envelope rather than mutating the receipt after signing.
+
+## Recommended emission flow
+
+1. Capture stable input and output bytes before any downstream formatting changes.
+2. Hash those bytes with `sha256` or `sha512`.
+3. Build the `payload` object.
+4. Canonicalize and sign the `payload` only.
+5. Write the receipt JSON plus a public-key fixture JSON file.
+6. Verify the emitted receipt with the CLI before treating the integration as trustworthy.
+
+## Rust reference example
+
+The current helper APIs make Rust the cleanest integration path today:
+
+```rust
+use anyhow::Result;
+use agent_receipts::{
+    Actor, ActorKind, ReceiptPayload, Tool, Transport, sha256_digest_string,
+    sign_receipt_payload_ml_dsa,
+};
+use std::fs;
+
+fn main() -> Result<()> {
+    let input_bytes = br#"{"path":"README.md"}"#;
+    let output_bytes = br#"{"bytes":1024}"#;
+
+    let payload = ReceiptPayload {
+        event_type: "tool_call".to_string(),
+        actor: Actor {
+            kind: ActorKind::Agent,
+            id: "agent:demo-runner".to_string(),
+            model: Some("claude-sonnet-4".to_string()),
+            session_id: Some("session:demo-002".to_string()),
+        },
+        tool: Tool {
+            name: "filesystem.read".to_string(),
+            version: Some("1.0.0".to_string()),
+            server: Some("mcp://demo.local/fs".to_string()),
+            transport: Transport::Mcp,
+        },
+        inputs_hash: sha256_digest_string(input_bytes),
+        outputs_hash: sha256_digest_string(output_bytes),
+        parent_receipt_id: None,
+    };
+
+    // Demo-only fixed seed. Replace with your real key custody in production.
+    let (receipt, public_key) = sign_receipt_payload_ml_dsa(
+        [7u8; 32],
+        "demo-ml-dsa-87",
+        "01JABCD0000000000000000000",
+        "2026-04-18T18:05:00Z",
+        payload,
+    )?;
+
+    fs::create_dir_all("demo-keys")?;
+    fs::write("demo-receipt.json", serde_json::to_vec_pretty(&receipt)?)?;
+    fs::write(
+        "demo-keys/demo-ml-dsa-87.public.json",
+        serde_json::to_vec_pretty(&public_key)?,
+    )?;
+
+    Ok(())
+}
+```
+
+Then verify what you emitted:
+
+```bash
+receipts verify demo-receipt.json --keys-dir demo-keys
+```
+
+## Non-Rust integrations today
+
+If your runtime is not Rust yet:
+
+- emit JSON that conforms to [spec/receipt-v1.schema.json](../spec/receipt-v1.schema.json)
+- emit public key fixture JSON shaped like the files in [testvectors/keys](../testvectors/keys)
+- run `receipts schema-check` and `receipts verify` in CI or in a validation step before you ship receipts downstream
+
+That keeps the public contract stable even before language-specific bindings land.
+
+## Batches and chains
+
+- Use `parent_receipt_id` when you want to preserve causal lineage between receipts.
+- Use `batch-v1` when you need Merkle inclusion proofs for a set of receipts.
+- Do not add batch metadata to an already signed receipt. Inclusion is a separate envelope.
+
+## Operational notes
+
+- Prefer ML-DSA-87 for new integrations.
+- Treat Ed25519 as transitional compatibility only.
+- Publish or distribute trusted public keys separately from the receipt itself.
+- The demo signing helpers are useful for reference implementations and fixtures, but production key custody remains your responsibility.
+
+## Validation checklist
+
+- Your receipts pass `receipts schema-check`.
+- Your receipts pass `receipts verify` against the intended public key set.
+- Your integration preserves stable byte capture for input and output hashing.
+- Your batching layer emits `batch-v1` instead of mutating signed receipts.

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -1,0 +1,104 @@
+# Quickstart
+
+This guide gets you from clone to verified receipt in under 10 minutes using the committed fixtures in this repo.
+
+## Prerequisites
+
+- `git`
+- Rust toolchain installed locally
+
+## 1. Clone the repo and inspect the CLI
+
+```bash
+git clone https://github.com/authenticiq/agent-receipts.git
+cd agent-receipts
+cargo run --bin receipts -- --help
+```
+
+You should see the available commands:
+
+```text
+schema-check
+verify
+verify-batch
+verify-chain
+inspect
+```
+
+## 2. Schema-check and verify a single receipt
+
+```bash
+cargo run --bin receipts -- schema-check testvectors/valid/minimal-single-ml-dsa-87.json
+cargo run --bin receipts -- verify testvectors/valid/minimal-single-ml-dsa-87.json
+```
+
+Expected output:
+
+```text
+schema-check ok: agent-receipts/v1
+verify ok: 01JABCD0000000000000000000
+```
+
+Those commands succeed because the repo already contains the matching public keys in `testvectors/keys` and the CLI uses that directory by default when you run from this checkout.
+
+## 3. Inspect the receipt body
+
+```bash
+cargo run --bin receipts -- inspect testvectors/valid/minimal-single-ml-dsa-87.json
+```
+
+This pretty-prints the receipt so you can see the signed `payload`, detached `signature`, and top-level envelope metadata.
+
+## 4. Verify the batch fixture
+
+```bash
+cargo run --bin receipts -- verify-batch testvectors/batches/two-receipts-valid-batch.json
+```
+
+Expected output:
+
+```text
+verify-batch ok: demo-stratum-2026-04-18
+```
+
+This recomputes leaf hashes and validates the Merkle root and proof paths rather than trusting the batch file blindly.
+
+## 5. Verify the lineage fixture
+
+```bash
+cargo run --bin receipts -- verify-chain testvectors/chains/three-step-lineage.json
+```
+
+Expected output:
+
+```text
+verify-chain ok: demo-chain-v1
+```
+
+This checks parent-child relationships and rejects missing-parent or cycle fixtures.
+
+## 6. See a failure mode
+
+```bash
+cargo run --bin receipts -- verify testvectors/invalid/tampered-output-hash.json
+```
+
+That command should exit non-zero because the signed payload was altered after signing.
+
+## 7. Verify your own files
+
+When you move beyond the repo fixtures, pass the public key directory explicitly:
+
+```bash
+receipts verify path/to/receipt.json --keys-dir path/to/public-keys
+receipts verify-batch path/to/batch.json --keys-dir path/to/public-keys
+receipts verify-chain path/to/chain.json --keys-dir path/to/public-keys
+```
+
+The `--keys-dir` directory should contain one or more public key fixture JSON files shaped like the examples in `testvectors/keys/`.
+
+## Next steps
+
+- Read [docs/INTEGRATION.md](INTEGRATION.md) to emit your own receipts.
+- Read [spec/RATIONALE.md](../spec/RATIONALE.md) for the design rules that signers and verifiers are expected to preserve.
+- Read [testvectors/MATRIX.md](../testvectors/MATRIX.md) for the current conformance suite contract.


### PR DESCRIPTION
## Summary
- replace the stale README draft with a real Week 1 README grounded in the current CLI and fixtures
- add a copy-paste quickstart for schema, single receipt, batch, and chain verification
- add an integration guide for the current Rust library surface and the non-Rust CLI validation path

## Validation
- cargo run --bin receipts -- verify testvectors/invalid/tampered-output-hash.json
- cargo install --locked --path . --root /tmp/agent-receipts-install-test
- /tmp/agent-receipts-install-test/bin/receipts --help
- cargo fmt --all --check
- cargo run --bin generate-fixtures
- git diff --exit-code -- testvectors
- cargo test
- ../.tools/gitleaks dir . --config gitleaks.toml