### PR TITLE
Fix release workflow target input

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable
-          targets: ${{ matrix.target }}
+          target: ${{ matrix.target }}
           cache: true
 
       - name: Build release binaries


### PR DESCRIPTION
## Summary
- change the setup-rust-toolchain input from `targets` to `target`
- remove the warning emitted during release matrix jobs

## Validation
- confirmed `.github/workflows/release.yml` no longer contains `targets:`
- ran `git diff --check`
